### PR TITLE
Track page numbers per category

### DIFF
--- a/app/js/controllers/categoryCtrl.js
+++ b/app/js/controllers/categoryCtrl.js
@@ -1,10 +1,27 @@
 four51.app.controller('CategoryCtrl', ['$routeParams', '$sce', '$scope', '$451', 'Category', 'Product', 'Nav',
 function ($routeParams, $sce, $scope, $451, Category, Product, Nav) {
+	var
+	categoryInteropKey = "451Custom.state.category.pageCache.categoryInteropID"
+	,categoryPageKey = "451Custom.state.category.pageCache.pageNumber"
+	,categoryInitialLoad = true
+	,currentCategory = "localStorage" in window ? window.localStorage.getItem(categoryInteropKey) : null
+	,currentPage = currentCategory && currentCategory == $routeParams.categoryInteropID ? +window.localStorage.getItem(categoryPageKey) : 1;
+
 	$scope.productLoadingIndicator = true;
 	$scope.settings = {
 		currentPage: 1,
 		pageSize: 40
 	};
+
+	if($routeParams.categoryInteropID != currentCategory){
+		if("localStorage" in window){
+			localStorage.removeItem(categoryInteropKey);
+			localStorage.removeItem(categoryPageKey);
+		}
+	}
+	else if(currentPage != $scope.settings.currentPage)
+		setTimeout(function(){ $scope.settings.currentPage = currentPage; },100);
+
 	$scope.trusted = function(d){
 		if(d) return $sce.trustAsHtml(d);
 	}
@@ -20,8 +37,15 @@ function ($routeParams, $sce, $scope, $451, Category, Product, Nav) {
 	}
 
 	$scope.$watch('settings.currentPage', function(n, o) {
-		if (n != o || (n == 1 && o == 1))
+		if("localStorage" in window && !categoryInitialLoad){
+			window.localStorage.setItem(categoryInteropKey,$routeParams.categoryInteropID);
+			window.localStorage.setItem(categoryPageKey,n);
+		}
+
+		if (n != o || (n == 1 && o == 1) || categoryInitialLoad)
 			_search();
+
+		categoryInitialLoad = false;
 	});
 
 	if ($routeParams.categoryInteropID) {
@@ -52,4 +76,5 @@ function ($routeParams, $sce, $scope, $451, Category, Product, Nav) {
 			$scope.sorter = s.replace(' DESC', "");
 		$scope.direction = s.indexOf('DESC') > -1;
 	});
+
 }]);


### PR DESCRIPTION
On initial loading of category view, set page number to the tracked number.  This patch uses the window.localStorage data cache if it exists.